### PR TITLE
FF bookmark work 

### DIFF
--- a/firefox/Dockerfile
+++ b/firefox/Dockerfile
@@ -2,3 +2,6 @@ FROM jlesage/firefox:latest
 
 # Replace noVNC ui script with a version disabling the clipboard
 COPY ui.js /opt/noVNC/app/ui.js
+
+# For Firefox Browser in ML workspace. Populate the bookmarks with resource web urls
+COPY bookmarks/places.sqlite /config/profile/places.sqlite


### PR DESCRIPTION
Added the logic in Dockerfile to copy from bookmarks directory to /config/profile the places.sqlite bookmark database. 
Reference - https://support.mozilla.org/en-US/kb/profiles-where-firefox-stores-user-data?redirectslug=Profiles&redirectlocale=en-US

- Needs testing to see if the bookmark shows up. 
- See the M1 screenshot and the AimAhead screenshot that the paths are different. 
- The layout in ML workspace should look the same in the Bookmark dropdown. 

<img width="954" alt="Local-M1-Mac-FF-Bookmark-baseline-2025-01-09-10 40 25AM" src="https://github.com/user-attachments/assets/82116975-6a9e-4553-8825-a37a8017e87d" />
<img width="971" alt="AimAhead-ML-Portal-FF-ProfileDir-2025-01-09-9 57 43AM" src="https://github.com/user-attachments/assets/28425e02-e867-44b6-993a-8bc74858d13e" />
