### PR TITLE
Add `azureml` packages to mlw-jupyter-kernel

### DIFF
--- a/mlw-jupyter-kernel/python/requirements.txt
+++ b/mlw-jupyter-kernel/python/requirements.txt
@@ -1,3 +1,5 @@
+azureml-core==1.56.0
+azureml-fsspec==1.3.1
 catboost==1.2.7
 dash==2.18.2
 joblib==1.4.2


### PR DESCRIPTION
To read directly from `azureml://` URIs, the `azureml-fsspec` package needs to be installed. I've also added the `azureml-core` package to the requirements since it may be necessary to work with the Datastores. Since I can't install external packages after the kernel is built, I haven't verified that this will allow one to directly read from a URI in this workspace yet. 

In a different Azure ML workspace environment, where I am able to install these packages, I can directly read from `azureml://` URIs. 