### PR TITLE
Add automated refresh jobs for dash-public and dash-users dashboards

### DIFF
--- a/dash-public/dash_chorus.py
+++ b/dash-public/dash_chorus.py
@@ -7,6 +7,8 @@ import pandas as pd
 import plotly.graph_objects as go
 import plotly as py
 import pathlib
+import os
+from datetime import datetime
 
 
 app = dash.Dash(
@@ -34,6 +36,14 @@ conditions_df = conditions_df_tmp[conditions_df_tmp["num_persons"]>=20] # SMALL 
 demograph_df = pd.read_csv("/app/data/demograph.csv", header=0)
 access_df = pd.read_csv("/app/data/access_details.csv", header=0)
 site_deid_df = pd.read_csv("/app/data/source_key.csv", header=0)
+
+# Read last-updated timestamp written by the refresh job
+TIMESTAMP_FILE = "/app/data/last_updated.txt"
+if os.path.exists(TIMESTAMP_FILE):
+    with open(TIMESTAMP_FILE, 'r') as f:
+        last_updated_str = f.read().strip()
+else:
+    last_updated_str = "Unknown"
 site_deid_dict = dict(zip(site_deid_df["s_name"],site_deid_df["s_key"]))
 person_ct_dict = dict(zip(persons_omop_df["site"],persons_omop_df["count_person"]))
 note_ct_dict = dict(zip(persons_omop_df["site"],persons_omop_df["count_note"]))
@@ -396,6 +406,17 @@ app.layout = html.Div(
             id="banner",
             className="banner",
             children=[html.Img(src=app.get_asset_url("chorus_multicolor.png")), html.H6("Bridge2AI for Clinical Care")],
+        ),
+        # Data refresh timestamp
+        html.Div(
+            f"Data last refreshed: {last_updated_str}",
+            style={
+                "fontSize": "12px",
+                "color": "#888",
+                "textAlign": "right",
+                "padding": "2px 14px",
+                "fontStyle": "italic",
+            },
         ),
         # Left column
         html.Div(

--- a/dash-public/job/Dockerfile
+++ b/dash-public/job/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.13-bookworm
+
+RUN apt-get update && \
+    apt-get install --yes --no-install-recommends \
+        postgresql-client && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip install azure-storage-blob \
+                azure-identity
+
+COPY *.sql /app/
+COPY job/refresh_data.py /app/refresh_data.py
+
+ENTRYPOINT ["python3", "/app/refresh_data.py"]

--- a/dash-public/job/refresh_data.py
+++ b/dash-public/job/refresh_data.py
@@ -1,0 +1,242 @@
+"""
+dash-public weekly refresh job
+
+Reads blob metadata from Azure Blob Storage, loads it into Postgres,
+runs SQL transformations, and exports CSV files to the shared data volume.
+
+Adapted from:
+  - dash/read_blob_chorus.py   (blob reading + Postgres loading)
+  - dash-public/export_dash_src.sh (SQL queries + CSV export)
+
+Environment variables required:
+  PILOT_CONN_STR  - Azure Storage connection string
+  PGHOST          - Postgres host  (default: localhost)
+  PGPORT          - Postgres port  (default: 5432)
+  PGUSER          - Postgres user  (default: postgres)
+  DATA_DIR        - Output directory for CSVs (default: /app/data)
+"""
+
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+from azure.storage.blob import BlobServiceClient
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+BLOB_CONN_STR = os.environ["PILOT_CONN_STR"]
+
+PGHOST = os.environ.get("PGHOST", "localhost")
+PGPORT = os.environ.get("PGPORT", "5432")
+PGUSER = os.environ.get("PGUSER", "postgres")
+DATA_DIR = os.environ.get("DATA_DIR", "/app/data")
+
+SITE_CONTAINERS = [
+    "columbia", "duke", "emory", "mayo", "mgh", "mit",
+    "nationwide", "pitts", "seattle", "tuft", "ucla",
+    "ucsf", "uflorida", "uva",
+]
+
+# Map raw container names → canonical site names used by OMOP DBs
+SITE_DB_MAP = {
+    "tuft": "tufts",
+    "pitts": "pittsburgh",
+    "uflorida": "florida",
+    "uva": "virginia",
+}
+
+BLOB_COLUMN_LIST = ["name", "container", "size", "last_modified", "creation_time"]
+
+# The 14 OMOP site databases to query for person/note counts
+OMOP_SITE_DBS = [
+    "columbia", "duke", "emory", "mgh", "mit", "mayo",
+    "nationwide", "ucla", "ucsf", "florida", "pittsburgh",
+    "seattle", "virginia", "tufts",
+]
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def run(cmd, **kwargs):
+    """Run a shell command, raising on failure."""
+    print(f"  > {cmd if isinstance(cmd, str) else ' '.join(cmd)}")
+    return subprocess.run(cmd, check=True, **kwargs)
+
+
+def psql(database, sql=None, file=None, copy_to=None):
+    """Execute a psql command against *database*."""
+    base = ["psql", "-h", PGHOST, "-p", PGPORT, "-U", PGUSER, "-d", database]
+    if file:
+        run(base + ["-f", file])
+    elif copy_to:
+        run(base + ["-c", copy_to])
+    elif sql:
+        run(base + ["-c", sql])
+
+
+def psql_scalar(database, sql):
+    """Return a single scalar value from a psql query."""
+    base = ["psql", "-h", PGHOST, "-p", PGPORT, "-U", PGUSER,
+            "-d", database, "-qtAX", "-c", sql]
+    result = subprocess.run(base, check=True, capture_output=True, text=True)
+    return result.stdout.strip()
+
+
+# ---------------------------------------------------------------------------
+# Stage 1 – Read blob metadata from Azure and load into Postgres
+# ---------------------------------------------------------------------------
+
+def stage_read_blobs():
+    print("\n=== Stage 1: Reading blob metadata from Azure Blob Storage ===")
+    blob_svc = BlobServiceClient.from_connection_string(conn_str=BLOB_CONN_STR)
+
+    # Re-create the raw metadata table
+    psql("ohdsi", sql="DROP TABLE IF EXISTS public.all_metadata;")
+    psql("ohdsi", sql="""
+        CREATE TABLE public.all_metadata(
+            file_id integer,
+            name text,
+            container text,
+            last_modified text,
+            size text,
+            creation_time text
+        );
+    """)
+
+    global_cnt = 0
+    tmp_csv = "/tmp/blob_metadata.csv"
+
+    for site_name in SITE_CONTAINERS:
+        print(f"  Listing blobs in container: {site_name}")
+        site_cc = blob_svc.get_container_client(site_name)
+        blobs = site_cc.list_blobs()
+
+        row_cnt = 0
+        with open(tmp_csv, "w") as f:
+            for blob in blobs:
+                if row_cnt == 0:
+                    # Write header once per site batch
+                    header = "id"
+                    for key in blob.keys():
+                        if key in BLOB_COLUMN_LIST:
+                            header += f",{key}"
+                    f.write(header + "\n")
+
+                line = str(global_cnt)
+                for key in blob.keys():
+                    if key in BLOB_COLUMN_LIST:
+                        line += f",{blob[key]}"
+                f.write(line + "\n")
+
+                global_cnt += 1
+                row_cnt += 1
+                if row_cnt % 100_000 == 0:
+                    print(f"    {row_cnt} blobs parsed...")
+
+        # Load CSV into Postgres
+        if row_cnt > 0:
+            copy_cmd = (
+                f"tail -q -n +2 {tmp_csv} | "
+                f"psql -h {PGHOST} -p {PGPORT} -U {PGUSER} -d ohdsi "
+                f"-c \"\\copy public.all_metadata FROM STDIN CSV DELIMITER E','\""
+            )
+            run(["bash", "-c", copy_cmd])
+        print(f"  {site_name}: {row_cnt} blobs loaded ({global_cnt} total)")
+
+    os.remove(tmp_csv) if os.path.exists(tmp_csv) else None
+    print(f"  Total blobs loaded: {global_cnt}")
+
+
+# ---------------------------------------------------------------------------
+# Stage 2 – Run SQL transformations
+# ---------------------------------------------------------------------------
+
+def stage_sql_transforms():
+    print("\n=== Stage 2: Running SQL transformations ===")
+
+    # Create all_metadata_expanded + by_site_metadata  (from dash/prep_for_export.sql logic)
+    # This is used by get_allfiles_grouped.sql
+    print("  Running prep_for_export.sql on ohdsi...")
+    psql("ohdsi", file="/app/prep_for_export.sql")
+
+    # Create allfiles_grouped (the main heatmap source)
+    print("  Running get_allfiles_grouped.sql on ohdsi...")
+    psql("ohdsi", file="/app/get_allfiles_grouped.sql")
+
+    # Create condition summary (on merge DB)
+    print("  Running get_condition_summary.sql on merge...")
+    psql("merge", file="/app/get_condition_summary.sql")
+
+    # Create demographics (on merge DB)
+    print("  Running get_demo_dash.sql on merge...")
+    psql("merge", file="/app/get_demo_dash.sql")
+
+
+# ---------------------------------------------------------------------------
+# Stage 3 – Export CSVs
+# ---------------------------------------------------------------------------
+
+def stage_export_csvs():
+    print("\n=== Stage 3: Exporting CSVs ===")
+    os.makedirs(DATA_DIR, exist_ok=True)
+
+    # allfiles_grouped.csv
+    psql("ohdsi", copy_to=f"\\copy public.allfiles_grouped TO '{DATA_DIR}/allfiles_grouped.csv' CSV HEADER")
+
+    # demograph.csv
+    psql("merge", copy_to=f"\\copy public.demo_dash TO '{DATA_DIR}/demograph.csv' CSV HEADER")
+
+    # source_key.csv
+    psql("merge", copy_to=f"\\copy persist.source_key TO '{DATA_DIR}/source_key.csv' CSV HEADER")
+
+    # chorus_conditions.csv
+    psql("merge", copy_to=f"\\copy public.domain_summary_condition TO '{DATA_DIR}/chorus_conditions.csv' CSV HEADER")
+
+    # omop_counts.csv  – per-site person and note counts
+    print("  Collecting per-site OMOP counts...")
+    omop_path = os.path.join(DATA_DIR, "omop_counts.csv")
+    with open(omop_path, "w") as f:
+        f.write("site, count_person, count_note\n")
+        for site_db in OMOP_SITE_DBS:
+            try:
+                count_person = psql_scalar(site_db, "SELECT count(*) FROM omopcdm.person;")
+                count_note = psql_scalar(site_db, "SELECT count(distinct(person_id)) FROM omopcdm.note;")
+                f.write(f"{site_db}, {count_person}, {count_note}\n")
+                print(f"    {site_db}: persons={count_person}, notes={count_note}")
+            except subprocess.CalledProcessError as e:
+                print(f"    WARNING: could not query {site_db}: {e}", file=sys.stderr)
+
+    print(f"  CSVs written to {DATA_DIR}/")
+
+
+# ---------------------------------------------------------------------------
+# Stage 4 – Write refresh timestamp
+# ---------------------------------------------------------------------------
+
+def stage_write_timestamp():
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    ts_path = os.path.join(DATA_DIR, "last_updated.txt")
+    with open(ts_path, "w") as f:
+        f.write(timestamp)
+    print(f"\n=== Data refresh completed at {timestamp} ===")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    print("=" * 60)
+    print("  dash-public weekly refresh job")
+    print("=" * 60)
+
+    stage_read_blobs()
+    stage_sql_transforms()
+    stage_export_csvs()
+    stage_write_timestamp()
+
+    print("Done.")

--- a/dash-public/prep_for_export.sql
+++ b/dash-public/prep_for_export.sql
@@ -1,0 +1,23 @@
+DROP TABLE IF EXISTS public.all_metadata_expanded;
+
+CREATE TABLE public.all_metadata_expanded AS (
+SELECT     name,
+           container,
+           last_modified::timestamp AS last_modified,
+           size::float AS size,
+           creation_time::timestamp AS creation_time,
+           date_part('year', last_modified::timestamp) AS year_modified,
+           date_part('month', last_modified::timestamp) AS month_modified,
+           FLOOR(((date_part('month', last_modified::timestamp)-1) / 3) + 1) AS quarter_modified,
+           date_part('year', creation_time::timestamp) AS year_created,
+           date_part('month', creation_time::timestamp) AS month_created,
+           FLOOR(((date_part('month', creation_time::timestamp)-1) / 3) + 1) AS quarter_created,
+           CASE WHEN char_length(split_part(name,'.', -1)) < 10 THEN split_part(name,'.', -1) END AS extension,
+           CASE WHEN lower(name) LIKE '%note%' OR lower(name) LIKE 'note%' THEN 'NOTE'
+                WHEN lower(name) LIKE '%omop%' OR lower(name) LIKE 'omop%' OR split_part(name,'.', -1) = 'csv' OR split_part(name,'.', -1) = 'xlsx' THEN 'OMOP'
+                WHEN lower(name) LIKE '%wave%' OR lower(name) LIKE 'wave%' THEN 'WAVE'
+                WHEN lower(name) LIKE '%image%' OR lower(name) LIKE 'image%' THEN 'IMAGE'
+           END AS mode,
+           CURRENT_TIMESTAMP AS loaded_at
+    FROM public.all_metadata WHERE size::float > 0
+);

--- a/dash-users/app.py
+++ b/dash-users/app.py
@@ -40,6 +40,14 @@ def data_load():
 df = data_load()
 loaded_at = df['loaded_at'][0]
 
+# Read last-updated timestamp written by the refresh job
+TIMESTAMP_FILE = '/az_users/data/last_updated.txt'
+if os.path.exists(TIMESTAMP_FILE):
+    with open(TIMESTAMP_FILE, 'r') as f:
+        last_updated_str = f.read().strip()
+else:
+    last_updated_str = str(loaded_at)[0:19]
+
 heading = html.H1("CHoRUS User Access Dashboard", className="bg-secondary text-white p-2 mb-4")
 
 about_card = dcc.Markdown(
@@ -73,6 +81,19 @@ app.layout = dbc.Container(
     [
         dcc.Store(id="store-permissions", data={}),
         heading,
+        # Data refresh timestamp
+        html.Div(
+            f"Data last refreshed: {last_updated_str}",
+            style={
+                "fontSize": "13px",
+                "color": "#888",
+                "textAlign": "right",
+                "padding": "2px 14px",
+                "fontStyle": "italic",
+                "marginTop": "-10px",
+                "marginBottom": "10px",
+            },
+        ),
         dcc.Markdown(id="title"),
         dbc.Row(dbc.Col([ dcc.Markdown(id="subtitle-1"), make_grid_group()]), className="my-4"),
 

--- a/dash-users/job/Dockerfile
+++ b/dash-users/job/Dockerfile
@@ -1,16 +1,15 @@
-from python:3.12-bookworm
+FROM python:3.12-bookworm
 
 RUN apt-get update && \
     apt-get install --yes --no-install-recommends \
-        cargo
+        cargo && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN pip install azure-identity \
                 azure-mgmt-resource \
                 msgraph-sdk \
                 pandas \
-                dash \
-                dash_bootstrap_components \
-                dash_ag_grid
+                requests
 
 COPY read_access_chorus.py /app/read_access_chorus.py
 

--- a/dash-users/read_access_chorus.py
+++ b/dash-users/read_access_chorus.py
@@ -197,5 +197,16 @@ for row in toIterate.itertuples():
 
 
 
-user_df['loaded_at'] = [datetime.datetime.now()] * user_df.shape[0]
-user_df.to_csv('/az_users/data/personnel_metadata.csv', index=False)
+user_df['loaded_at'] = [datetime.datetime.now(datetime.timezone.utc)] * user_df.shape[0]
+
+# Save to shared volume
+output_dir = os.environ.get('OUTPUT_DIR', '/az_users/data')
+os.makedirs(output_dir, exist_ok=True)
+user_df.to_csv(os.path.join(output_dir, 'personnel_metadata.csv'), index=False)
+
+# Write refresh timestamp
+timestamp = datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+with open(os.path.join(output_dir, 'last_updated.txt'), 'w') as f:
+    f.write(timestamp)
+
+print(f"Data saved to {output_dir}/personnel_metadata.csv at {timestamp}")


### PR DESCRIPTION
**Resolves:** https://github.com/chorus-ai/cloud_public/issues/13

@jshoughtaling @dgunda1 - Ready for review and testing with real Azure files.

Adds Azure Container Apps Job definitions for both dash-public and dash-users to automate their data refresh pipelines, replacing the current manual/stale update process.

#### Changes

**dash-public** (weekly refresh)

* **Dockerfile** – New: Job image with `postgresql-client`, `azure-storage-blob`, `azure-identity`
* **refresh_data.py** – New: Python job script adapted from read_blob_chorus.py. Reads blob metadata from Azure Blob Storage via `PILOT_CONN_STR`, loads into Postgres `all_metadata` table, runs SQL transforms (prep_for_export.sql → get_allfiles_grouped.sql → get_condition_summary.sql → get_demo_dash.sql), exports 5 CSVs + `last_updated.txt` to `$DATA_DIR`
* **prep_for_export.sql** – New: Creates `all_metadata_expanded` from raw `all_metadata` (sourced from prep_for_export.sql, trimmed to the transform needed by get_allfiles_grouped.sql)
* **dash_chorus.py** – Modified: Reads `last_updated.txt` at startup and displays "Data last refreshed: ..." timestamp below the banner

**dash-users** (daily refresh)

* **Dockerfile** – Modified: Removed unused dash/`dash_bootstrap_components`/`dash_ag_grid`; added `requests`
* **read_access_chorus.py** – Modified: Added CSV output (`personnel_metadata.csv`) + `last_updated.txt` to `$OUTPUT_DIR` (default `/az_users/data/`). Uses UTC-aware timestamps
* **app.py** – Modified: Reads `last_updated.txt` and displays "Data last refreshed: ..." timestamp below the heading

#### Environment variables required

* `PILOT_CONN_STR` – dash-public – Azure Storage connection string
* `PGHOST`, `PGPORT`, `PGUSER` – dash-public – Postgres connection (defaults: `localhost`, `5432`, `postgres`)
* `DATA_DIR` – dash-public – CSV output path (default: data)
* `OUTPUT_DIR` – dash-users – CSV output path (default: `/az_users/data`)
* `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_SECRET`, etc. – dash-users – Existing env vars for MS Graph / Azure Resource Manager

#### Deployment

Both jobs should be deployed as Azure Container Apps Jobs with shared Azure Files volume mounts so the refreshed CSVs are immediately available to the dashboard containers:

* **dash-public:** cron `0 0 * * 0` (weekly, Sunday midnight UTC)
* **dash-users:** cron `0 0 * * *` (daily, midnight UTC)