### PR TITLE
Add InterpretML to mlw-jupyter-kernel requirements.txt

### DIFF
--- a/mlw-jupyter-kernel/python/requirements.txt
+++ b/mlw-jupyter-kernel/python/requirements.txt
@@ -38,3 +38,4 @@ h5py==3.13.0
 biosppy==2.2.3
 timm==1.0.15
 tf-keras-vis==0.8.7
+interpret==0.7.8


### PR DESCRIPTION
This is a request to add the latest version of InterpretML (https://interpret.ml/) to the Jupyter environment for AIM-AHEAD trainees.