### PR TITLE
Add dash-cytoscape and kaleido for handling plotly figures

### DIFF
--- a/mlw-jupyter-kernel/python/requirements.txt
+++ b/mlw-jupyter-kernel/python/requirements.txt
@@ -39,3 +39,5 @@ biosppy==2.2.3
 timm==1.0.15
 tf-keras-vis==0.8.7
 interpret==0.7.8
+dash-cytoscape==1.0.2
+kaleido==1.3.0


### PR DESCRIPTION
We use `interpret` to model our cohort. This package's primary output format is based on plotly. We hope to added two packages to help interactively visualize and export this figure format. Thanks!